### PR TITLE
Use `<<~EOS` instead of `<<-EOS.undent`

### DIFF
--- a/et.rb
+++ b/et.rb
@@ -4,6 +4,7 @@ class Et < Formula
   url "https://github.com/MisterTea/EternalTCP/archive/et-v4.1.2.tar.gz"
   version "4.1.2"
   sha256 "94aeab8fbebe2df843aa324659d418ba9061b9bbfef8b31d805e95987f28122e"
+  revision 1
 
   depends_on "cmake" => :build
 
@@ -20,7 +21,7 @@ class Et < Formula
 
   plist_options :startup => true
 
-  def plist; <<-EOS.undent
+  def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
     <plist version="1.0">


### PR DESCRIPTION
As per commit 77f1768 on Homebrew, the Homebrew-specific idiom `<<-EOS.undent` **has been deprecated** in favor of the more general `<<~EOS` syntax:

> https://github.com/Homebrew/brew/commit/77f1768108272f2168e22a735bead49fe7045331#diff-d667e35be86b1a2b5d1f95ff39b4a878R3

This PR upgrades the `et` formula to reflect this change. Without this change, installing or upgrading Homebrew formulas will fail:

![image](https://user-images.githubusercontent.com/1239874/35196812-9cc373f8-fed7-11e7-8da8-aa54d18b947f.png)

Note: This PR introduces a temporary stanza `revision 1`, which is to allow users to upgrade in case they are already stuck with the old 4.1.2 formula. Feel free to remove the line `revision 1` on the next release.