### PR TITLE
Make EternalTerminal 6.0.5 available via Homebrew

### DIFF
--- a/et.rb
+++ b/et.rb
@@ -1,10 +1,10 @@
 class Et < Formula
   desc "Remote terminal with IP roaming"
   homepage "https://mistertea.github.io/EternalTerminal/"
-  url "https://github.com/MisterTea/EternalTerminal/archive/et-v6.0.4.tar.gz"
+  url "https://github.com/MisterTea/EternalTerminal/archive/et-v6.0.5.tar.gz"
   head "https://github.com/MisterTea/EternalTerminal.git"
-  version "6.0.4"
-  sha256 "410dd72ade571c32c83302d38fba76e2c9dbe9916b61a4e9f673cb110f43c328"
+  version "6.0.5"
+  sha256 "c029bb0f2d474e13428d0a88853d6596a929814f6ffaa6d2ef4ad436c0127d57"
   revision 1
 
   depends_on "cmake" => :build


### PR DESCRIPTION
EternalTerminal 6.0.5 [has been released](https://github.com/MisterTea/EternalTerminal/releases/tag/et-v6.0.5), but the [Homebrew](https://brew.sh/) tap for EternalTerminal is still pointing at version 6.0.4. This change makes EternalTerminal 6.0.5 available via EternalTerminal's Homebrew tap.

Note: I obtained the value for `sha256` by doing this:

```sh
% openssl version
LibreSSL 2.6.5
% wget -q -O - https://github.com/MisterTea/EternalTerminal/archive/et-v6.0.5.tar.gz | openssl dgst -sha256
c029bb0f2d474e13428d0a88853d6596a929814f6ffaa6d2ef4ad436c0127d57
```